### PR TITLE
Auto-collect *.py Files for Pylint; Remove Sphinx Build From Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       run: git describe --dirty --always --tags
     - name: PyLint
       run: |
-        pylint adafruit_testrepo.py
+        pylint $( find . -path './adafruit*.py' )
         ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace examples/*.py)
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
         pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
-    - name: Build docs
-      working-directory: docs
-      run: sphinx-build -E -W -b html . _build/html
     - name: Upload Release Assets
       # the 'official' actions version does not yet support dynamically
       # supplying asset names to upload. @csexton's version chosen based on


### PR DESCRIPTION
- Generalize and auto-collect `.py` library files to run pylint on.
   - Uses `find` to gather py files, but limits to `adafruit`. `./adafruit_foo.py` and `./adafruit_foo/__init__.py` locations will both be found.
   - Thanks again to @ednl for helping to shorten the `find` pattern search.

- Remove the Sphinx build from `release.yml`. Sphinx builds for verification are accomplished in pushes/pull requests.