### PR TITLE
Deploy To PyPI Only When Necessary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get install -y gettext
         pip install -r requirements.txt
-        pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
+        pip install circuitpython-build-tools
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Upload Release Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Check For setup.py
+      id: need-pypi
+      run: |
+        echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
     - name: Set up Python
+      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       uses: actions/setup-python@v1
       with:
         python-version: '3.x'
     - name: Install dependencies
+      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Build and publish
+      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       env:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This ensures that deployment steps for PyPI won't error out if `setup.py` doesn't exists in the top directory. Should be an acceptable assumption if a library is on PyPI, as well.