### PR TITLE
Move Pip Installs Back To build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,13 @@ jobs:
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci
-    - name: Install deps
+    - name: Install dependencies
+      # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
         source actions-ci/install.sh
+    - name: Pip install pylint, black, & Sphinx
+      run: |
+        pip install --force-reinstall pylint==1.9.2 black==19.10b0 Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
     - name: PyLint


### PR DESCRIPTION
This is the Step 1 to address the final decisions in: https://github.com/adafruit/actions-ci-circuitpython-libs/issues/2

Moves pylint, black, and Sphinx+theme pip installs back into `build.yml`, from `actions-ci/install.sh`.

(_I'll update that issue thread with my new plan of attack in a minute..._)

I've run an `adabot.patches` dry-run on this already. It reports 6 repos being skipped with no failures; will narrow down which 6 later.

Let me know of any desired changes.