### PR TITLE
Correct Code of Conduct copyright and license.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -82,7 +82,7 @@ In any situation, you may send an email to <support@adafruit.com>.
 On the Adafruit Discord, you may send an open message from any channel
 to all Community Moderators by tagging @community moderators. You may
 also send an open message from any channel, or a direct message to
-@kattni#1507, @tannewt#4653, @Dan Halbert#1614, @cater#2442,
+@kattni#1507, @tannewt#4653, @danh#1614, @cater#2442,
 @sommersoft#0222, @Mr. Certainly#0472 or @Andon#8175.
 
 Email and direct message reports will be kept confidential.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,9 @@
 <!--
+SPDX-FileCopyrightText: 2014 Coraline Ada Ehmke
 SPDX-FileCopyrightText: 2019 Kattni Rembor for Adafruit Industries
 
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC-BY-4.0
 -->
-
 # Adafruit Community Code of Conduct
 
 ## Our Pledge


### PR DESCRIPTION
As pointed out by @tannewt in
https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/75,
the CoC is derived off the Contributor Covenant, and is also released as
CC-BY-4.0 (see https://github.com/adafruit/Adafruit_Community_Code_of_Conduct).