### PR TITLE
Add docs/requirements.txt with sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+sphinx>=4.0.0


### PR DESCRIPTION
Should fix the issue RTD is having with building the docs, and also matches the other libraries which is probably useful for this library in particularly.