### PR TITLE
Add tick counter

### DIFF
--- a/adafruit_testrepo.py
+++ b/adafruit_testrepo.py
@@ -22,6 +22,11 @@ Implementation Notes
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
 
+note::
+
+    PyPI will reject a release if no source code has changed.
+    Please increment this counter if needed: 1
+
 """
 
 __version__ = "0.0.0-auto.0"

--- a/pyproject.toml.disabled
+++ b/pyproject.toml.disabled
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
-# SPDX-FileCopyrightText: Copyright (c) 2021 Foamyguy for Adafruit Industries
-#
-# SPDX-License-Identifier: MIT
-#
-# This library is not deployed to PyPI. It is either a board-specific helper library, or
-# does not make sense for use on or is incompatible with single board computers and Linux.
-#


### PR DESCRIPTION
* Removed `pyproject.toml.disabled` since `pyproject.toml` was previously added
* Added a tick counter since PyPI will reject releases that don't actually contain source code changes since the last release.